### PR TITLE
Prevent configuration variables from being overridden

### DIFF
--- a/services/Disqus_UtilsService.php
+++ b/services/Disqus_UtilsService.php
@@ -43,7 +43,9 @@ class Disqus_UtilsService extends BaseApplicationComponent
 
             echo <<<ENDBLOCK
 <script type="text/javascript">
+var _old_disqus_config = disqus_config ;
 var disqus_config = function() {
+    _old_disqus_config.apply(this);
     this.page.remote_auth_s3 = "$message $hmac $timestamp";
     this.page.api_key = "$disqusPublicKey";
 
@@ -65,7 +67,9 @@ ENDBLOCK;
             $disqusPublicKey = $settings['disqusPublicKey'];
             echo <<<ENDBLOCK
 <script type="text/javascript">
+var _old_disqus_config = disqus_config ;
 var disqus_config = function() {
+    _old_disqus_config.apply(this);
     this.page.remote_auth_s3 = "$message $hmac $timestamp";
     this.page.api_key = "$disqusPublicKey";
 };

--- a/services/Disqus_UtilsService.php
+++ b/services/Disqus_UtilsService.php
@@ -90,8 +90,7 @@ ENDBLOCK;
 
         if ($settings['useSSO'])
             $this->outputSSOTag();
-
-        $disqusShortname = $settings['disqusShortname'];
+        $disqusShortname = (craft()->config->get('disqusShortname', 'disqus')) ?: $settings['disqusShortname'];
         echo <<<ENDBLOCK
 <div id="disqus_thread"></div>
 <script type="text/javascript">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,8 +1,21 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
-'label': 'Disqus Site Short Name', 'instructions': 'Enter your Disqus Site Short Name here.', 'id': 'disqusShortname', 'name': 'disqusShortname', 'value': settings['disqusShortname']}) }}
+{% macro configWarning(setting) -%}
+  {{ "This is being overridden by the {setting} config setting in your disqus.php config file."|t({
+    setting: setting
+  })|raw }}
+{%- endmacro %}
+{% from _self import configWarning %}
 
+{{ forms.textField({
+  'label':        'Disqus Site Short Name', 
+  'instructions': 'Enter your Disqus Site Short Name here.',
+  'id':           'disqusShortname',
+  'name':         'disqusShortname',
+  'value':        settings['disqusShortname'],
+  'warning':      (craft.config.get('disqusShortname', 'disqus') is not sameas(null)) ? configWarning('disqusShortname'),
+
+}) }}
 <hr />
 
 <p>Please see <a href="https://help.disqus.com/customer/portal/articles/236206-integrating-single-sign-on" target="_blank">Integrating Single Sign-On</a> for details on how to set up your Disqus account to use SSO</p>


### PR DESCRIPTION
e.g. for multi-lingual sites you can now do

```
<script>
var disqus_config = function () {  
    this.language = "{{entry.locale}}";
}
</script>
{{ disqusEmbed( entry.id ~ "_" ~ entry.locale}}
```

Thanks for the plugin! Maybe this is a change you are interested in as well.
