### PR TITLE
Fixes Disqus from loading when encoding the URL

### DIFF
--- a/services/Disqus_UtilsService.php
+++ b/services/Disqus_UtilsService.php
@@ -85,7 +85,6 @@ ENDBLOCK;
         $settings = craft()->plugins->getPlugin('disqus')->getSettings();
         $disqusIdentifier = json_encode($disqusIdentifier);
         $disqusTitle = json_encode($disqusTitle);
-        $disqusUrl = json_encode($disqusUrl);
         $disqusCategoryId = json_encode($disqusCategoryId);
         if ($settings['useSSO'])
             $this->outputSSOTag();


### PR DESCRIPTION
After updating with your latest update, Disqus started displaying a generic error saying it won't load. After reverting the update it worked again... I was able to narrow down the culprit to when the URL is encoded. I simply removed that line and it's working again.
