### PR TITLE
Resolve broken $disqusIdentifier encoding when set as a string.

### DIFF
--- a/services/Disqus_UtilsService.php
+++ b/services/Disqus_UtilsService.php
@@ -83,7 +83,7 @@ ENDBLOCK;
     {
         $result = "";
         $settings = craft()->plugins->getPlugin('disqus')->getSettings();
-        $disqusIdentifier = json_encode($disqusIdentifier);
+        $disqusIdentifier = json_encode((int)$disqusIdentifier);
         $disqusTitle = json_encode($disqusTitle);
         $disqusUrl = json_encode($disqusUrl);
         $disqusCategoryId = json_encode($disqusCategoryId);


### PR DESCRIPTION
If $disqusIdentifier is passed as a string, json_encode will wrap it with an additional set of quotes. Casting $disqusIdentifier to an int resolves the issue.
