### PR TITLE
json_encode issue

### DIFF
--- a/services/Disqus_UtilsService.php
+++ b/services/Disqus_UtilsService.php
@@ -79,13 +79,16 @@ ENDBLOCK;
     Output the Disqus Tag
 -------------------------------------------------------------------------------- */
 
-    public function outputEmbedTag($disqusIdentifier = "", $disqusTitle = "", $disqusUrl = "", $disqusCategoryId = "")
+    public function outputEmbedTag($disqusIdentifier = '', $disqusTitle = '', $disqusUrl = '', $disqusCategoryId = '')
     {
-        $result = "";
+        // Set all parameters to single quote so that double quotes don't get wrapped in single quotes
+        // json_encode does not need to happen for the javascript variables, they can just be added
+        // disqusIdentifier still needs to be parsed as a integer
+
+        $result = '';
         $settings = craft()->plugins->getPlugin('disqus')->getSettings();
-        $disqusIdentifier = json_encode((int)$disqusIdentifier);
-        $disqusTitle = json_encode($disqusTitle);
-        $disqusCategoryId = json_encode($disqusCategoryId);
+        $disqusIdentifier = (int)$disqusIdentifier;
+        
         if ($settings['useSSO'])
             $this->outputSSOTag();
 


### PR DESCRIPTION
Parameters were getting based to javascript as '""' and not allowing new posts to be able to be commented on, disqus error was being returned. Testing locally shows that none of the parameters need to be json_encoded, I presume because we are not building a json object to be passed.
