### PR TITLE
Expose settings

### DIFF
--- a/variables/DisqusVariable.php
+++ b/variables/DisqusVariable.php
@@ -17,5 +17,8 @@ class DisqusVariable
     {
 		return craft()->disqus_utils->outputEmbedTag($disqusIdentifier, $disqusTitle, $disqusUrl, $disqusCategoryId);
     } /* -- disqusEmbed */
-
+	
+    function getSettings() {
+        return craft()->plugins->getPlugin('disqus')->getSettings();
+    }
 }


### PR DESCRIPTION
Expose settings to twig so that you can handle multiple environments using different shortnames.
